### PR TITLE
1.7.6.9 compatibility fix

### DIFF
--- a/controllers/front/login.php
+++ b/controllers/front/login.php
@@ -43,16 +43,8 @@ class LoginAsCustomerLoginModuleFrontController extends ModuleFrontControllerCor
         if ($id_customer && (Tools::getValue('xtoken') == $token)) {
             $customer = new Customer((int) $id_customer);
             if (Validate::isLoadedObject($customer)) {
-                $customer->logged = 1;
-                $this->context->customer = $customer;
-                $this->context->cookie->id_customer = (int) $customer->id;
-                $this->context->cookie->customer_lastname = $customer->lastname;
-                $this->context->cookie->customer_firstname = $customer->firstname;
-                $this->context->cookie->logged = 1;
-                $this->context->cookie->check_cgv = 1;
-                $this->context->cookie->is_guest = $customer->isGuest();
-                $this->context->cookie->passwd = $customer->passwd;
-                $this->context->cookie->email = $customer->email;
+                Context::getContext()->updateCustomer($customer);
+
                 Tools::redirect('index.php?controller=my-account');
             }
         }


### PR DESCRIPTION
The manual cookie writing does not work with 1.7.6.9, as the isSessionAlive() check fails to verify registered session. Therefore use the Context::updateCustomer() method to properly log in the customer.